### PR TITLE
Ensure token is returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Deprecate the `authenticate` method in favor of the new `token` method
 - Allow to configure from which path to get the access token
 - Put all errors into the AccessTokenAgent namespace
+- Actually return a token when faking auth
 
 ## 3.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Allow to configure from which path to get the access token
 - Put all errors into the AccessTokenAgent namespace
 - Actually return a token when faking auth
+- Rename error raised for unsupported token types
+- Ensure that access token response carries an access token
 
 ## 3.1.1
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Needs the following parameters to instantiate:
 Optional parameters:
 
 * `fake_auth` - if true, do not connect to the auth service and return
-   an empty access token (`nil`).
+   a faked access token.
 
 ### Example
 

--- a/lib/access_token_agent/connector.rb
+++ b/lib/access_token_agent/connector.rb
@@ -2,6 +2,8 @@ require 'net/http'
 
 module AccessTokenAgent
   class Connector
+    FAKE_TOKEN = 'FakeAuthToken'.freeze
+
     def initialize(host:,
                    client_id:,
                    client_secret:,
@@ -19,7 +21,7 @@ module AccessTokenAgent
     end
 
     def token
-      return if @fake_auth
+      return FAKE_TOKEN if @fake_auth
       @known_token = fetch_token unless @known_token && @known_token.valid?
 
       @known_token.value

--- a/lib/access_token_agent/missing_access_token.rb
+++ b/lib/access_token_agent/missing_access_token.rb
@@ -1,0 +1,7 @@
+module AccessTokenAgent
+  class MissingAccessToken < Error
+    def initialize
+      super('The access token response did not contain an access token.')
+    end
+  end
+end

--- a/lib/access_token_agent/unsupported_token_type_error.rb
+++ b/lib/access_token_agent/unsupported_token_type_error.rb
@@ -1,5 +1,5 @@
 module AccessTokenAgent
-  class InvalidTokenTypeError < Error
+  class UnsupportedTokenTypeError < Error
     def initialize(token_type)
       super("Expected token_type to be 'bearer', but was '#{token_type}'.")
     end

--- a/spec/access_token_agent/connector_spec.rb
+++ b/spec/access_token_agent/connector_spec.rb
@@ -18,7 +18,7 @@ describe AccessTokenAgent::Connector do
       let(:known_token) do
         AccessTokenAgent::Token.new('expires_in' => 7200,
                                     'token_type' => 'bearer',
-                                    value: 'xy')
+                                    'access_token' => 'xy')
       end
 
       before { agent.instance_variable_set(:@known_token, known_token) }

--- a/spec/access_token_agent/token_spec.rb
+++ b/spec/access_token_agent/token_spec.rb
@@ -3,7 +3,13 @@ require 'spec_helper'
 module AccessTokenAgent
   describe Token do
     subject { Token.new(auth_response) }
-    let(:auth_response) { { 'token_type' => 'bearer', 'expires_in' => 3600 } }
+    let(:auth_response) do
+      {
+        'token_type' => 'bearer',
+        'expires_in' => 3600,
+        'access_token' => 'test'
+      }
+    end
 
     describe '.valid?' do
       context 'when token has not expired' do
@@ -11,7 +17,13 @@ module AccessTokenAgent
       end
 
       context 'when Token has expired' do
-        let(:auth_response) { { 'token_type' => 'bearer', 'expires_in' => 0 } }
+        let(:auth_response) do
+          {
+            'token_type' => 'bearer',
+            'expires_in' => 0,
+            'access_token' => 'test'
+          }
+        end
         it { is_expected.not_to be_valid }
       end
     end
@@ -23,10 +35,29 @@ module AccessTokenAgent
       end
 
       context 'when token_type is not supported' do
-        let(:auth_response) { { 'token_type' => 'mac', 'expires_in' => 3600 } }
+        let(:auth_response) do
+          {
+            'token_type' => 'mac',
+            'expires_in' => 3600,
+            'access_token' => 'test'
+          }
+        end
+
+        it 'raises an UnsupportedTokenTypeError' do
+          expect { subject }.to raise_error UnsupportedTokenTypeError
+        end
+      end
+
+      context 'when access_token is missing' do
+        let(:auth_response) do
+          {
+            'token_type' => 'bearer',
+            'expires_in' => 3600
+          }
+        end
 
         it 'raises an InvalidTokenTypeError' do
-          expect { subject }.to raise_error InvalidTokenTypeError
+          expect { subject }.to raise_error MissingAccessToken
         end
       end
     end


### PR DESCRIPTION
This PR ensures that the `token` method will always return an access token or fail clearly:

* Raise error, if the token obtained from the endpoint is empty
* Let fake auth return an actual string
* Rename `InvalidTokenTypeError` to `UnsupportedTokenTypeError`

**Note**: The renaming of the `InvalidTokenTypeError` is technically a  breaking change.
However at the current state of this gem, we know everyone using it. And nobody is rescuing this exception. That is why I would like to let this change "slip through" without bumping the major version.