### PR TITLE
Add accessor for shared connector instance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,28 +1,34 @@
 AllCops:
-  TargetRubyVersion: 2.1
   Exclude:
+    - 'bin/**/*'
     - 'db/schema.rb'
     - 'doc/**/*'
-    - 'Gemfile'
-    - '*.gemspec'
+    - 'docker_app/**/*'
+    - 'Guardfile'
+    - 'tmp/**/*'
+    - 'vendor/**/*'
 
-Style/AsciiComments:
-  Enabled: false
+# We need to configure exemptions for blocks that we generally accept to be
+# long, since they are less comparable to methods and more comparable to
+# modules/classes.
+Metrics/BlockLength:
+  ExcludedMethods:
+    - context
+    - describe
+    - namespace
+  Exclude:
+    - 'config/environments/*.rb' # instead of excluding all :configure methods
+    - 'config/routes.rb'
 
 Style/Documentation:
   Enabled: false
-
-# Encoding comments are not neccessary in all 2.x versions of ruby, since
-# UTF-8 has become the default encoding.
-Style/Encoding:
-  EnforcedStyle: never
-  Enabled: true
 
 # This cop tries to make you use module_funtion instead of extend self
 # This is bad because both have their own use-case and should not be used
 # and sometimes cannot be used to do the same thing
 Style/ModuleFunction:
   Enabled: false
+
 # While it is very often useful to separate numbers after every three digits
 # for readability, this mostly doesn't make sense if the number doesn't
 # represent an amount but rather an identifier. Thus the use of underscores

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 script:
-  - bundle exec rspec
+  - bundle exec rspec && codeclimate-test-reporter
   - bundle exec rubocop
 
 addons:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 *no unreleased changes*
 
+## 3.3.0
+
+- Add `instance` accessor to `AccessTokenAgent::Connector`
+
 ## 3.2.1
 
 - Use a string as key in HTTP headers, to be compatible with Ruby < 2.3

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in auth_connector.gemspec

--- a/README.md
+++ b/README.md
@@ -49,13 +49,25 @@ Optional parameters:
                                              client_secret: 'very_secure_and_secret')
 ```
 
+## Sharing a connector
+
+When connecting to multiple endpoints you will commonly come across the need
+to share a single instance of a connector in multiple places, because your
+application will use the same configuration everywhere.
+
+You can use the convenience accessor `instance` for that:
+
+```ruby
+AccessTokenAgent::Connector.instance = AccessTokenAgent::Connector.new(...)
+```
+
 ## Usage
 
 Setup an AcccessTokenAgent::Connector instance (see Configuration) and call
-authenticate on it to receive your access_token.
+`authenticate` on it to receive your access_token.
 
 ```ruby
-@connector.authenticate
+AccessTokenAgent::Connector.instance.authenticate
  => "XYZ"
 ```
 
@@ -75,6 +87,6 @@ determined by the auth response which contains an `expires_at` parameter.
 Since the most common use case is to include the access token as [RFC 6750](https://tools.ietf.org/html/rfc6750) bearer token, there is a method that returns the `Authorization: Bearer XYZ` header as hash:
 
 ```ruby
-@connector.http_auth_header
- => { "Authorization" => "Bearer XYZ" } 
+AccessTokenAgent::Connector.instance.http_auth_header
+ => { "Authorization" => "Bearer XYZ" }
 ```

--- a/access_token_agent.gemspec
+++ b/access_token_agent.gemspec
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'access_token_agent/version'
@@ -19,11 +17,11 @@ Gem::Specification.new do |s|
                                    .reject { |f| f.match(%r{^spec/}) }
 
   s.add_development_dependency 'bundler', '~> 1.11'
-  s.add_development_dependency 'rspec', '~> 3.4'
+  s.add_development_dependency 'codeclimate-test-reporter'
   s.add_development_dependency 'pry', '~> 0.10'
-  s.add_development_dependency 'rubocop', '~> 0.39'
+  s.add_development_dependency 'rspec', '~> 3.4'
+  s.add_development_dependency 'rubocop', '0.51'
+  s.add_development_dependency 'simplecov', '~> 0.11'
   s.add_development_dependency 'vcr', '~> 3.0'
   s.add_development_dependency 'webmock', '~> 1.24'
-  s.add_development_dependency 'simplecov', '~> 0.11'
-  s.add_development_dependency 'codeclimate-test-reporter'
 end

--- a/access_token_agent.gemspec
+++ b/access_token_agent.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
                                    .reject { |f| f.match(%r{^spec/}) }
 
   s.add_development_dependency 'bundler', '~> 1.11'
-  s.add_development_dependency 'codeclimate-test-reporter'
+  s.add_development_dependency 'codeclimate-test-reporter', '~> 1.0'
   s.add_development_dependency 'pry', '~> 0.10'
   s.add_development_dependency 'rspec', '~> 3.4'
   s.add_development_dependency 'rubocop', '0.51'

--- a/lib/access_token_agent/connector.rb
+++ b/lib/access_token_agent/connector.rb
@@ -4,6 +4,10 @@ module AccessTokenAgent
   class Connector
     FAKE_TOKEN = 'FakeAuthToken'.freeze
 
+    class << self
+      attr_accessor :instance
+    end
+
     def initialize(host:,
                    client_id:,
                    client_secret:,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-require 'codeclimate-test-reporter'
 require 'simplecov'
-CodeClimate::TestReporter.start
 SimpleCov.start
 SimpleCov.add_filter 'spec'
 


### PR DESCRIPTION
This PR adds the global accessor `AccessTokenAgent::Connector.instance`, which can be used by applications to store and retrieve a shared instance of a connector.

This is a comparable idea to `Redis.current`, except there is no default configuration we will fall back to.

### Background

Internally we noticed that the usual client of this gem has exactly one configuration of the access token agent, which will either be duplicated in a lot of places or get its own self-made singleton accessor per application.