### PR TITLE
Allow token_type value (i.e., "bearer") to be case-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 *no unreleased changes*
 
+## 3.4.0
+
+- Allows value of `token_type` to have any casing
+
 ## 3.3.0
 
 - Add `instance` accessor to `AccessTokenAgent::Connector`

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ OAuth2 [client credentials flow](https://tools.ietf.org/html/rfc6749#section-4.4
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'access_token_agent', '~> 3.1'
+gem 'access_token_agent', '~> 3.4'
 ```
 
 And then execute:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ And then execute:
 
     $ bundle
 
-## Basic Configuration
+## Basic configuration
 
 Create an instance of AccessTokenAgent::Connector with the desired
 configuration and use that instance to authenticate.
@@ -63,7 +63,7 @@ AccessTokenAgent::Connector.instance = AccessTokenAgent::Connector.new(...)
 
 ## Usage
 
-Setup an AcccessTokenAgent::Connector instance (see Configuration) and call
+Set up an AcccessTokenAgent::Connector instance (see Configuration) and call
 `authenticate` on it to receive your access_token.
 
 ```ruby

--- a/access_token_agent.gemspec
+++ b/access_token_agent.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry', '~> 0.10'
   s.add_development_dependency 'rspec', '~> 3.4'
   s.add_development_dependency 'rubocop', '0.51'
-  s.add_development_dependency 'simplecov', '~> 0.11'
+  s.add_development_dependency 'simplecov', '~> 0.16'
   s.add_development_dependency 'vcr', '~> 3.0'
   s.add_development_dependency 'webmock', '~> 1.24'
 end

--- a/lib/access_token_agent/missing_token_type.rb
+++ b/lib/access_token_agent/missing_token_type.rb
@@ -1,0 +1,7 @@
+module AccessTokenAgent
+  class MissingTokenType < Error
+    def initialize
+      super('The access token response did not contain a token type.')
+    end
+  end
+end

--- a/lib/access_token_agent/token.rb
+++ b/lib/access_token_agent/token.rb
@@ -21,7 +21,7 @@ module AccessTokenAgent
     private
 
     def validate_response(auth_response)
-      unless auth_response['token_type'] == 'bearer'
+      unless auth_response['token_type'].downcase == 'bearer'
         raise UnsupportedTokenTypeError, auth_response['token_type']
       end
 

--- a/lib/access_token_agent/token.rb
+++ b/lib/access_token_agent/token.rb
@@ -1,4 +1,5 @@
 require 'access_token_agent/missing_access_token'
+require 'access_token_agent/missing_token_type'
 require 'access_token_agent/unsupported_token_type_error'
 
 module AccessTokenAgent
@@ -21,6 +22,7 @@ module AccessTokenAgent
     private
 
     def validate_response(auth_response)
+      raise MissingTokenType if auth_response['token_type'].nil?
       unless auth_response['token_type'].downcase == 'bearer'
         raise UnsupportedTokenTypeError, auth_response['token_type']
       end

--- a/lib/access_token_agent/version.rb
+++ b/lib/access_token_agent/version.rb
@@ -1,3 +1,3 @@
 module AccessTokenAgent
-  VERSION = '3.3.0'.freeze
+  VERSION = '3.4.0'.freeze
 end

--- a/spec/access_token_agent/token_spec.rb
+++ b/spec/access_token_agent/token_spec.rb
@@ -60,6 +60,19 @@ module AccessTokenAgent
           expect { subject }.to raise_error MissingAccessToken
         end
       end
+
+      context 'when token_type is missing' do
+        let(:auth_response) do
+          {
+            'expires_in' => 3600,
+            'access_token' => 'test'
+          }
+        end
+
+        it 'raises a MissingTokenTypeError' do
+          expect { subject }.to raise_error MissingTokenType
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This is an intermediate step to the breaking change of requiring `Bearer` to be title case. Allowing both `bearer` and `Bearer` for now will allow the gem to be compatible with versions 5.0.0 and above of `doorkeeper`, which enforces `Bearer` (per [the OAuth 2 RFC](https://tools.ietf.org/html/rfc6750#section-6.1.1)).

Closes https://github.com/kaeuferportal/access_token_agent/issues/4