### PR TITLE
Require token_type value (i.e., "Bearer") to be title case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 *no unreleased changes*
 
+## 4.0.0
+
+- Breaking change: Require value of `token_type` to be title case (i.e., `Bearer`), to match the [Oauth 2 RFC](https://tools.ietf.org/html/rfc6750) and be compatible with `doorkeeper` version 5.0.0+
+
 ## 3.4.0
 
-- Allows value of `token_type` to have any casing
+- Allow value of `token_type` to have any casing
 
 ## 3.3.0
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ OAuth2 [client credentials flow](https://tools.ietf.org/html/rfc6749#section-4.4
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'access_token_agent', '~> 3.4'
+gem 'access_token_agent', '~> 4.0'
 ```
 
 And then execute:

--- a/lib/access_token_agent/token.rb
+++ b/lib/access_token_agent/token.rb
@@ -23,7 +23,7 @@ module AccessTokenAgent
 
     def validate_response(auth_response)
       raise MissingTokenType if auth_response['token_type'].nil?
-      unless auth_response['token_type'].downcase == 'bearer'
+      unless auth_response['token_type'] == 'Bearer'
         raise UnsupportedTokenTypeError, auth_response['token_type']
       end
 

--- a/lib/access_token_agent/unsupported_token_type_error.rb
+++ b/lib/access_token_agent/unsupported_token_type_error.rb
@@ -1,7 +1,7 @@
 module AccessTokenAgent
   class UnsupportedTokenTypeError < Error
     def initialize(token_type)
-      super("Expected token_type to be 'bearer', but was '#{token_type}'.")
+      super("Expected token_type to be 'Bearer', but was '#{token_type}'.")
     end
   end
 end

--- a/lib/access_token_agent/version.rb
+++ b/lib/access_token_agent/version.rb
@@ -1,3 +1,3 @@
 module AccessTokenAgent
-  VERSION = '3.4.0'.freeze
+  VERSION = '4.0.0'.freeze
 end

--- a/spec/access_token_agent/connector_spec.rb
+++ b/spec/access_token_agent/connector_spec.rb
@@ -17,7 +17,7 @@ describe AccessTokenAgent::Connector do
     context 'when an access_token is known for the credentials' do
       let(:known_token) do
         AccessTokenAgent::Token.new('expires_in' => 7200,
-                                    'token_type' => 'bearer',
+                                    'token_type' => 'Bearer',
                                     'access_token' => 'xy')
       end
 

--- a/spec/access_token_agent/token_spec.rb
+++ b/spec/access_token_agent/token_spec.rb
@@ -5,7 +5,7 @@ module AccessTokenAgent
     subject { Token.new(auth_response) }
     let(:auth_response) do
       {
-        'token_type' => 'bearer',
+        'token_type' => 'Bearer',
         'expires_in' => 3600,
         'access_token' => 'test'
       }
@@ -19,7 +19,7 @@ module AccessTokenAgent
       context 'when Token has expired' do
         let(:auth_response) do
           {
-            'token_type' => 'bearer',
+            'token_type' => 'Bearer',
             'expires_in' => 0,
             'access_token' => 'test'
           }
@@ -51,7 +51,7 @@ module AccessTokenAgent
       context 'when access_token is missing' do
         let(:auth_response) do
           {
-            'token_type' => 'bearer',
+            'token_type' => 'Bearer',
             'expires_in' => 3600
           }
         end

--- a/spec/fixtures/vcr_cassettes/AccessTokenAgent_Connector/_fetch_token_hash/when_credentials_are_valid/returns_a_Hash_containing_expires_in.yml
+++ b/spec/fixtures/vcr_cassettes/AccessTokenAgent_Connector/_fetch_token_hash/when_credentials_are_valid/returns_a_Hash_containing_expires_in.yml
@@ -50,7 +50,7 @@ http_interactions:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: '{"access_token":"6c8ca820662ab58086de897d59ff4686a144cb977d4efbc30c6743a9f35938e2","token_type":"bearer","expires_in":7200,"created_at":1460709239}'
+      string: '{"access_token":"6c8ca820662ab58086de897d59ff4686a144cb977d4efbc30c6743a9f35938e2","token_type":"Bearer","expires_in":7200,"created_at":1460709239}'
     http_version: 
   recorded_at: Fri, 15 Apr 2016 08:33:59 GMT
 recorded_with: VCR 3.0.1

--- a/spec/fixtures/vcr_cassettes/AccessTokenAgent_Connector/_fetch_token_hash/when_credentials_are_valid/returns_a_Hash_containing_the_access_token.yml
+++ b/spec/fixtures/vcr_cassettes/AccessTokenAgent_Connector/_fetch_token_hash/when_credentials_are_valid/returns_a_Hash_containing_the_access_token.yml
@@ -50,7 +50,7 @@ http_interactions:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: '{"access_token":"eeb81b0efe8d0792e8e41cd9eab6df75d68f48bbd7b600f332d9bd154981ec51","token_type":"bearer","expires_in":7200,"created_at":1460709239}'
+      string: '{"access_token":"eeb81b0efe8d0792e8e41cd9eab6df75d68f48bbd7b600f332d9bd154981ec51","token_type":"Bearer","expires_in":7200,"created_at":1460709239}'
     http_version: 
   recorded_at: Fri, 15 Apr 2016 08:33:59 GMT
 recorded_with: VCR 3.0.1

--- a/spec/fixtures/vcr_cassettes/AccessTokenAgent_Connector/_fetch_token_hash/when_request_is_not_successful/throws_an_Error.yml
+++ b/spec/fixtures/vcr_cassettes/AccessTokenAgent_Connector/_fetch_token_hash/when_request_is_not_successful/throws_an_Error.yml
@@ -50,7 +50,7 @@ http_interactions:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: '{"access_token":"b4430823efcd40091e5a577fc56aafc2bfda507f5ef325febcf2ca588d316ed4","token_type":"bearer","expires_in":7200,"created_at":1460709239}'
+      string: '{"access_token":"b4430823efcd40091e5a577fc56aafc2bfda507f5ef325febcf2ca588d316ed4","token_type":"Bearer","expires_in":7200,"created_at":1460709239}'
     http_version:
   recorded_at: Fri, 15 Apr 2016 08:33:59 GMT
 recorded_with: VCR 3.0.1

--- a/spec/fixtures/vcr_cassettes/AccessTokenAgent_Connector/_token/when_an_access_token_is_known_for_the_credentials/and_it_is_invalid/and_the_credentials_are_valid/calls_auth_project.yml
+++ b/spec/fixtures/vcr_cassettes/AccessTokenAgent_Connector/_token/when_an_access_token_is_known_for_the_credentials/and_it_is_invalid/and_the_credentials_are_valid/calls_auth_project.yml
@@ -50,7 +50,7 @@ http_interactions:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: '{"access_token":"17d1ae2d4a2e3f0c01b409d6f952fe67c37f48d71a2490a87665a424d8dea750","token_type":"bearer","expires_in":7200,"created_at":1460708990}'
+      string: '{"access_token":"17d1ae2d4a2e3f0c01b409d6f952fe67c37f48d71a2490a87665a424d8dea750","token_type":"Bearer","expires_in":7200,"created_at":1460708990}'
     http_version: 
   recorded_at: Fri, 15 Apr 2016 08:29:50 GMT
 recorded_with: VCR 3.0.1

--- a/spec/fixtures/vcr_cassettes/AccessTokenAgent_Connector/_token/when_an_access_token_is_known_for_the_credentials/and_it_is_invalid/and_the_credentials_are_valid/does_not_return_the_known_token_value.yml
+++ b/spec/fixtures/vcr_cassettes/AccessTokenAgent_Connector/_token/when_an_access_token_is_known_for_the_credentials/and_it_is_invalid/and_the_credentials_are_valid/does_not_return_the_known_token_value.yml
@@ -50,7 +50,7 @@ http_interactions:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: '{"access_token":"83f08f41879acbaf7ced58ae82db7c194139debb77ef937737d96a0c48dfb2ca","token_type":"bearer","expires_in":7200,"created_at":1460708990}'
+      string: '{"access_token":"83f08f41879acbaf7ced58ae82db7c194139debb77ef937737d96a0c48dfb2ca","token_type":"Bearer","expires_in":7200,"created_at":1460708990}'
     http_version: 
   recorded_at: Fri, 15 Apr 2016 08:29:50 GMT
 recorded_with: VCR 3.0.1

--- a/spec/fixtures/vcr_cassettes/AccessTokenAgent_Connector/_token/when_an_access_token_is_known_for_the_credentials/and_it_is_invalid/and_the_credentials_are_valid/returns_a_new_token_value.yml
+++ b/spec/fixtures/vcr_cassettes/AccessTokenAgent_Connector/_token/when_an_access_token_is_known_for_the_credentials/and_it_is_invalid/and_the_credentials_are_valid/returns_a_new_token_value.yml
@@ -50,7 +50,7 @@ http_interactions:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: '{"access_token":"fa9724f775c8949bb2d680c7cf11f4d40b92879f16987c0929a78e7a3ce893f4","token_type":"bearer","expires_in":7200,"created_at":1460708990}'
+      string: '{"access_token":"fa9724f775c8949bb2d680c7cf11f4d40b92879f16987c0929a78e7a3ce893f4","token_type":"Bearer","expires_in":7200,"created_at":1460708990}'
     http_version: 
   recorded_at: Fri, 15 Apr 2016 08:29:50 GMT
 recorded_with: VCR 3.0.1

--- a/spec/fixtures/vcr_cassettes/AccessTokenAgent_Connector/_token/when_no_access_token_is_known_for_the_credentials/and_the_credentials_are_valid/calls_auth_project.yml
+++ b/spec/fixtures/vcr_cassettes/AccessTokenAgent_Connector/_token/when_no_access_token_is_known_for_the_credentials/and_the_credentials_are_valid/calls_auth_project.yml
@@ -50,7 +50,7 @@ http_interactions:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: '{"access_token":"9ef44d144fc3cea9b23d4e2307bd3fc2e32c1449841bad6b8817d42a28bd6aac","token_type":"bearer","expires_in":7200,"created_at":1460709075}'
+      string: '{"access_token":"9ef44d144fc3cea9b23d4e2307bd3fc2e32c1449841bad6b8817d42a28bd6aac","token_type":"Bearer","expires_in":7200,"created_at":1460709075}'
     http_version: 
   recorded_at: Fri, 15 Apr 2016 08:31:15 GMT
 recorded_with: VCR 3.0.1

--- a/spec/fixtures/vcr_cassettes/AccessTokenAgent_Connector/_token/when_no_access_token_is_known_for_the_credentials/and_the_credentials_are_valid/returns_a_new_token_value.yml
+++ b/spec/fixtures/vcr_cassettes/AccessTokenAgent_Connector/_token/when_no_access_token_is_known_for_the_credentials/and_the_credentials_are_valid/returns_a_new_token_value.yml
@@ -50,7 +50,7 @@ http_interactions:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: '{"access_token":"b9143de417609e7302bd84fa13034c7557c1eb69a7aad7362b033c3b4002a858","token_type":"bearer","expires_in":7200,"created_at":1460709075}'
+      string: '{"access_token":"b9143de417609e7302bd84fa13034c7557c1eb69a7aad7362b033c3b4002a858","token_type":"Bearer","expires_in":7200,"created_at":1460709075}'
     http_version: 
   recorded_at: Fri, 15 Apr 2016 08:31:15 GMT
 recorded_with: VCR 3.0.1


### PR DESCRIPTION
This will require the value of `token_type` to be title case (i.e., `Bearer`), to match the [Oauth 2 RFC](https://tools.ietf.org/html/rfc6750) and be compatible with `doorkeeper` version 5.0.0+.

Follow-up to https://github.com/kaeuferportal/access_token_agent/pull/5

